### PR TITLE
chore: harden CODEOWNERS for OSPO branch protection

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,11 @@
-* @jung-thomas
+# Code owners for hana-hdbext-promisfied-example
+# Either of the listed owners can approve a pull request to satisfy
+# the "Require review from Code Owners" branch ruleset.
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-security/customizing-your-repository/about-code-owners
+
+# Default ownership: any maintainer can approve
+* @jung-thomas @rich-heilman
+
+# CI/CD and release plumbing — keep maintainers on the loop for these
+/.github/workflows/ @jung-thomas @rich-heilman
+/scripts/ @jung-thomas @rich-heilman


### PR DESCRIPTION
## Summary

Resolves the **OSPO Hardening Control #5** ("Restrict main / release branches with Branch Restrictions") finding by completing the code-owner review setup that the new branch ruleset requires.

## What changed

The repository's main-branch ruleset (`Protect main branch`, ID `16755708`) was updated to require:
- ✅ 1 approving review per PR
- ✅ Code-owner review (`require_code_owner_review: true`)
- ✅ Dismiss stale reviews on push
- ✅ Require approval of the most-recent push
- ✅ Resolve all review threads before merge

A new ruleset (`Protect release tags`, ID `17119297`) protects release tag patterns from deletion / force-update:
- `refs/tags/hdb/v*`
- `refs/tags/hdbext/v*`
- `refs/tags/hdbhelper/v*`
- `refs/tags/hdbhelper-py/v*`

This PR expands [`.github/CODEOWNERS`](.github/CODEOWNERS) so:
- Either `@jung-thomas` or `@rich-heilman` can approve any PR (no single-owner bottleneck)
- Changes under `/.github/workflows/` and `/scripts/` always require a maintainer

## Related

- OSPO Hardening Controls dashboard
- Control #6 (Environments) shipped in 6842803
- Control #4 (long-lived secrets / OIDC) covered by `release-python.yml` trusted publishers