### PR TITLE
chore: sync main with published 2.202606.1 + fix release workflow

### DIFF
--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -23,6 +23,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
@@ -72,9 +73,12 @@ jobs:
           npm publish --provenance
 
       - name: Commit version bump
+        id: bump
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          BRANCH="release/${{ inputs.package }}-${{ inputs.version }}"
+          git checkout -b "$BRANCH"
           FILES=""
           if [[ "${{ inputs.package }}" == "hdb" || "${{ inputs.package }}" == "both" ]]; then
             FILES="$FILES hdb/package.json hdb/npm-shrinkwrap.json"
@@ -84,10 +88,14 @@ jobs:
           fi
           git add $FILES
           if [[ "${{ inputs.package }}" == "both" ]]; then
-            git commit -m "chore(hdb,hdbext): bump version to ${{ inputs.version }}"
+            COMMIT_MSG="chore(hdb,hdbext): bump version to ${{ inputs.version }}"
           else
-            git commit -m "chore(${{ inputs.package }}): bump version to ${{ inputs.version }}"
+            COMMIT_MSG="chore(${{ inputs.package }}): bump version to ${{ inputs.version }}"
           fi
+          git commit -m "$COMMIT_MSG"
+          git push origin "$BRANCH"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "title=$COMMIT_MSG" >> "$GITHUB_OUTPUT"
 
       - name: Create and push tags
         run: |
@@ -102,4 +110,14 @@ jobs:
             git tag -a "$TAG" -m "Release $TAG"
             TAGS="$TAGS $TAG"
           fi
-          git push origin HEAD $TAGS
+          git push origin $TAGS
+
+      - name: Open PR for version bump
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create \
+            --base main \
+            --head "${{ steps.bump.outputs.branch }}" \
+            --title "${{ steps.bump.outputs.title }}" \
+            --body "Automated version bump from the **Release Node.js Package** workflow. Packages have already been published to npm and tags have been pushed; this PR records the version bump on \`main\`."

--- a/hdb/npm-shrinkwrap.json
+++ b/hdb/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
     "name": "sap-hdb-promisfied",
-    "version": "2.202604.1",
+    "version": "2.202606.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "sap-hdb-promisfied",
-            "version": "2.202604.1",
+            "version": "2.202606.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "@sap/xsenv": "^6.2.0",

--- a/hdb/package.json
+++ b/hdb/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sap-hdb-promisfied",
-    "version": "2.202604.1",
+    "version": "2.202606.1",
     "description": "Promise wrapper for hdb without any dependency to @sap/hana-client",
     "main": "./index.cjs",
     "exports": {

--- a/hdbext/npm-shrinkwrap.json
+++ b/hdbext/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
     "name": "sap-hdbext-promisfied",
-    "version": "2.202604.1",
+    "version": "2.202606.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "sap-hdbext-promisfied",
-            "version": "2.202604.1",
+            "version": "2.202606.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "@sap/hdbext": "^8.1.13",

--- a/hdbext/package.json
+++ b/hdbext/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sap-hdbext-promisfied",
-    "version": "2.202604.1",
+    "version": "2.202606.1",
     "description": "Promise wrapper for @sap/hdbext",
     "main": "./index.cjs",
     "exports": {


### PR DESCRIPTION
## Why

The **Release Node.js Package** workflow ran for \`2.202606.1\` and **succeeded** at the parts that matter:
- ✅ \`sap-hdb-promisfied@2.202606.1\` published to npm
- ✅ \`sap-hdbext-promisfied@2.202606.1\` published to npm
- ✅ tags \`hdb/v2.202606.1\` and \`hdbext/v2.202606.1\` pushed to GitHub

…but the final \`git push origin HEAD -> main\` (the version-bump commit) was **rejected** by branch protection:

\`\`\`
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
remote: - 7 of 7 required status checks are expected.
\`\`\`

So \`main\` still says \`2.202604.1\` in \`hdb/package.json\` and \`hdbext/package.json\` even though npm has \`2.202606.1\`.

## What this PR does

1. **Bumps \`hdb\` and \`hdbext\` to \`2.202606.1\`** in \`package.json\` and \`npm-shrinkwrap.json\` so \`main\` matches the published artifacts and tags.
2. **Patches [release-node.yml](.github/workflows/release-node.yml)** so this won't happen again — the version-bump now goes to a \`release/<package>-<version>\` branch and opens a PR via \`gh\` instead of pushing directly to \`main\`. Tag pushes are unchanged (tags aren't covered by the branch rule).

## Follow-ups (not in this PR)

- [release-go.yml](.github/workflows/release-go.yml) and [release-python.yml](.github/workflows/release-python.yml) very likely have the same direct-push-to-main bug. They haven't been exercised since branch protection tightened, so they'll fail the same way next time.
- PR #24 (dependency updates) was open at the time of release, so the published \`2.202606.1\` packages contain the **previous** dep versions. After this PR merges, #24 should rebase on top — its next release will pick up the dep bumps.