### PR TITLE
ci: route python release version bump through a PR

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -15,6 +15,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      pull-requests: write
     defaults:
       run:
         working-directory: hdbhelper-py
@@ -48,22 +49,40 @@ jobs:
           pip install build
           python -m build
 
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: hdbhelper-py/dist/
+
       - name: Commit version bump
+        id: bump
         working-directory: .
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          BRANCH="release/hdbhelper-py-${{ inputs.version }}"
+          git checkout -b "$BRANCH"
           git add hdbhelper-py/pyproject.toml
-          git commit -m "chore(hdbhelper-py): bump version to ${{ inputs.version }}"
+          COMMIT_MSG="chore(hdbhelper-py): bump version to ${{ inputs.version }}"
+          git commit -m "$COMMIT_MSG"
+          git push origin "$BRANCH"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "title=$COMMIT_MSG" >> "$GITHUB_OUTPUT"
 
       - name: Create and push tag
         working-directory: .
         run: |
           TAG="hdbhelper-py/v${{ inputs.version }}"
           git tag -a "$TAG" -m "Release $TAG"
-          git push origin HEAD "$TAG"
+          git push origin "$TAG"
 
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: hdbhelper-py/dist/
+      - name: Open PR for version bump
+        working-directory: .
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create \
+            --base main \
+            --head "${{ steps.bump.outputs.branch }}" \
+            --title "${{ steps.bump.outputs.title }}" \
+            --body "Automated version bump from the **Release Python Package** workflow. The package has already been published to PyPI and the tag has been pushed; this PR records the version bump on \`main\`."


### PR DESCRIPTION
Follow-up to #25, which fixed the same direct-push-to-\`main\` bug in [release-node.yml](.github/workflows/release-node.yml).

## Why

Branch protection on \`main\` requires PRs + 7 status checks. The release workflows pushed the version-bump commit directly to \`main\`, which now fails:

\`\`\`
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
remote: - 7 of 7 required status checks are expected.
\`\`\`

## Changes to [release-python.yml](.github/workflows/release-python.yml)

- Add \`pull-requests: write\` permission so the workflow can open a PR.
- **Reorder steps**: PyPI publish now runs before the git push, so a publish failure doesn't leave an orphan release branch sitting on the remote.
- Push the version-bump commit to a \`release/hdbhelper-py-<version>\` branch instead of \`main\`.
- Open a PR via \`gh\` after publish + tag succeed.
- Tag push is unchanged — tags aren't covered by the branch rule.

## Why [release-go.yml](.github/workflows/release-go.yml) is **not** modified

The Go release flow only pushes a tag — Go modules read their version from the tag itself, so there's no \`go.mod\` rewrite, no commit to \`main\`, and no \`git push HEAD\` step. Tags pass through branch protection cleanly. I checked the file and confirmed: nothing to fix there.

## After this merges

Next time you dispatch **Release Python Package**, the wheel publishes to PyPI, the tag pushes, and a PR appears with the \`pyproject.toml\` bump for someone to review and merge — same shape as the npm flow now.