### PR TITLE
chore: reconcile main with published release versions (2026-07-13)

### DIFF
--- a/hdb/npm-shrinkwrap.json
+++ b/hdb/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
     "name": "sap-hdb-promisfied",
-    "version": "2.202606.2",
+    "version": "2.202607.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "sap-hdb-promisfied",
-            "version": "2.202606.2",
+            "version": "2.202607.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "@sap/xsenv": "^6.2.0",

--- a/hdb/package.json
+++ b/hdb/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sap-hdb-promisfied",
-    "version": "2.202606.2",
+    "version": "2.202607.1",
     "description": "Promise wrapper for hdb without any dependency to @sap/hana-client",
     "main": "./index.cjs",
     "exports": {

--- a/hdbext/npm-shrinkwrap.json
+++ b/hdbext/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
     "name": "sap-hdbext-promisfied",
-    "version": "2.202606.2",
+    "version": "2.202607.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "sap-hdbext-promisfied",
-            "version": "2.202606.2",
+            "version": "2.202607.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "@sap/hdbext": "^8.1.13",

--- a/hdbext/package.json
+++ b/hdbext/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sap-hdbext-promisfied",
-    "version": "2.202606.2",
+    "version": "2.202607.1",
     "description": "Promise wrapper for @sap/hdbext",
     "main": "./index.cjs",
     "exports": {

--- a/hdbhelper-py/pyproject.toml
+++ b/hdbhelper-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sap-hdbhelper-py"
-version = "1.0.1"
+version = "1.0.2"
 description = "Python helper for SAP HANA — wraps hdbcli with environment resolution, SQL execution, and stored procedure support"
 requires-python = ">=3.12"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

The 2026-07-13 release workflows (Node, Python) published new versions to npm/PyPI and created release tags, but their version-bump commits were tagged only — they were **not** merged back to `main`. As a result `main`'s manifests lag behind the published artifacts. This PR brings `main` back in sync.

Cherry-picks the two bot-authored bump commits that the release workflows created:
- `b6a851e` — bump hdb + hdbext to 2.202607.1
- `96d3ac7` — bump hdbhelper-py to 1.0.2

### Version reconciliation

| Package | main (before) | Published | main (after) |
|---------|---------------|-----------|--------------|
| hdb (`sap-hdb-promisfied`, npm) | 2.202606.2 | **2.202607.1** | 2.202607.1 ✅ |
| hdbext (`sap-hdbext-promisfied`, npm) | 2.202606.2 | **2.202607.1** | 2.202607.1 ✅ |
| hdbhelper-py (`sap-hdbhelper-py`, PyPI) | 1.0.1 | **1.0.2** | 1.0.2 ✅ |

Note: **hdbhelper (Go)** needs no change — Go module versions are derived from the git tag (`hdbhelper/v1.0.2`), there is no in-repo version file to bump.

### Files changed
- `hdb/package.json`, `hdb/npm-shrinkwrap.json`
- `hdbext/package.json`, `hdbext/npm-shrinkwrap.json`
- `hdbhelper-py/pyproject.toml`

No functional/dependency changes — version strings only. No new publish is triggered by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)